### PR TITLE
Align structures with ADR after migrating the document to the Enhance…

### DIFF
--- a/cfApplication.go
+++ b/cfApplication.go
@@ -3,17 +3,18 @@ package main
 // Application represents an interpretation of a runtime Cloud Foundry application. This structure differs in that
 // the information it contains has been processed to simplify its transformation to a Kubernetes manifest using MTA
 type Application struct {
+	// Metadata captures the name, labels and annotations in the application
 	Metadata Metadata `json:",inline"`
 	// Env captures the `env` field values in the CF application manifest.
 	Env map[string]string `json:"env,omitempty"`
+	// Routes represent the routes that are made available by the .
+	Routes Routes `json:"routes,omitempty"`
 	// Services captures the `services` field values in the CF application manifest.
 	Services Services `json:"services,omitempty"`
 	// Processes captures the `processes` field values in the CF application manifest.
 	Processes Processes `json:"processes,omitempty"`
 	// Sidecars captures the `sidecars` field values in the CF application manifest.
 	Sidecars Sidecars `json:"sidecars,omitempty"`
-	// Instances configures the number of Cloud Foundry application instances.
-	Instances uint `json:"instances"`
 	// Stack represents the `stack` field in the application manifest. The value is captured for information
 	// purposes because it has no relevance in Kubernetes.
 	Stack string `json:"stack,omitempty"`
@@ -22,6 +23,8 @@ type Application struct {
 	// fail the deployment of the application. By default its 60 seconds.
 	// https://github.com/cloudfoundry/docs-dev-guide/blob/96f19d9d67f52ac7418c147d5ddaa79c957eec34/deploy-apps/large-app-deploy.html.md.erb#L35
 	StartupTimeout uint `json:"startupTimeout,omitempty"`
+	// Replicas configures the number of Cloud Foundry application instances.
+	Replicas uint `json:"replicas"`
 }
 
 // Metadata captures the name, labels and annotations in the application
@@ -37,16 +40,16 @@ type Metadata struct {
 // Routes represents a slice of Routes
 type Routes []Route
 
-// Route captures the key elements that define a Route: hostname, protocol and port. These values
+// Route captures the key elements that define a Route: fqdn, protocol and port. These values
 // are captured as runtime routes, meaning that if the CF Application manifest is configured to disable all routes
 // with the `no-route` value, it will translate into an empty slice.
-// Unless specified by the process or setting the application field `no-route` to true,
-// by default CloudFoundry will always attempt to create a route for each application.
+// By default CloudFoundry will always attempt to create a route for each application, unless specified by the field `no-route` when true
 // For further details check: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#no-route
 // and https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#random-route
 type Route struct {
-	// Hostname contains the hostname that will be used for the route.
-	Hostname string `json:"hostname"`
+	// FQDN captures the Fully Qualified Domain Name of the hostname field in the route. If the hostname contained a port
+	// its value it captured in the `Port` field in the Route structure.
+	FQDN string `json:"fqdn"`
 	// Protocol captures the protocol type: http, http2 or tcp.
 	Protocol RouteProtocol `json:"protocol"`
 	// Port captures the port to use for the route. For RouteProtocol `http`` it is 80; for `http2` it's 443,
@@ -84,26 +87,20 @@ type Processes []Process
 type Process struct {
 	// Type captures the `type` field in the Process specification. Accepted values are `web` or `worker`
 	Type ProcessType `json:"type,omitempty"`
-	// Name represents the name of the process.
-	Name string `json:"name"`
 	// Image represents the pull spec of the container image.
 	Image string `json:"image"`
-	// Memory represents the amount of memory requested by the process.
-	Memory string `json:"memory,omitempty"`
+	// Command represents the command used to run the process.
+	Command []string `json:"command,omitempty"`
 	// DiskQuota represents the amount of persistent disk requested by the process.
 	DiskQuota string `json:"disk,omitempty"`
+	// Memory represents the amount of memory requested by the process.
+	Memory string `json:"memory,omitempty"`
 	// HealthCheck captures the health check information
 	HealthCheck Probe `json:"healthCheck"`
 	// ReadinessCheck captures the readiness check information.
 	ReadinessCheck Probe `json:"readinessCheck"`
-	// Command represents the command used to run the process.
-	Command []string `json:"command,omitempty"`
 	// Replicas represents the number of instances for this process to run.
 	Replicas uint `json:"replicas"`
-	// Env define the list of k/v values to inject to the running container.
-	Env map[string]interface{} `json:"env,omitempty"`
-	// Routes represent the routes that are made available by the process's open port.
-	Routes Routes `json:"routes,omitempty"`
 	// LogRateLimit represents the maximum amount of logs to be captured per second.
 	LogRateLimit string `json:"logRateLimit,omitempty"`
 }

--- a/cfApplication.go
+++ b/cfApplication.go
@@ -3,7 +3,7 @@ package main
 // Application represents an interpretation of a runtime Cloud Foundry application. This structure differs in that
 // the information it contains has been processed to simplify its transformation to a Kubernetes manifest using MTA
 type Application struct {
-	// Metadata captures the name, labels and annotations in the application
+	// Metadata captures the name, labels and annotations in the application.
 	Metadata Metadata `json:",inline"`
 	// Env captures the `env` field values in the CF application manifest.
 	Env map[string]string `json:"env,omitempty"`

--- a/cfApplication.go
+++ b/cfApplication.go
@@ -46,7 +46,7 @@ type Routes []Route
 // Route captures the key elements that define a Route in a string that maps to a URL structure. These values
 // are captured as runtime routes, meaning that if the CF Application manifest is configured to disable all routes
 // with the `no-route` value, it will translate into an empty slice.
-// By default CloudFoundry will always attempt to create a route for each application, unless specified by the field `no-route` when true
+// By default Cloud Foundry attempts to create a route for each application unless the `no-route` field is set to true.
 // For further details check: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#no-route
 // and https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#random-route
 // Example

--- a/cfApplication.go
+++ b/cfApplication.go
@@ -7,7 +7,7 @@ type Application struct {
 	Metadata Metadata `json:",inline"`
 	// Env captures the `env` field values in the CF application manifest.
 	Env map[string]string `json:"env,omitempty"`
-	// Routes represent the routes that are made available by the .
+	// Routes represent the routes that are made available by the application.
 	Routes Routes `json:"routes,omitempty"`
 	// Services captures the `services` field values in the CF application manifest.
 	Services Services `json:"services,omitempty"`

--- a/cfApplication.go
+++ b/cfApplication.go
@@ -59,8 +59,7 @@ type Routes []Route
 //	- route: www.example.com/foo
 //	- route: tcp-example.com:1234
 type Route struct {
-	// URL captures the Fully Qualified Domain Name of the hostname field in the route. If the hostname contained a port
-	// its value it captured in the `Port` field in the Route structure.
+	// URL captures the FQDN, path and port of the route.
 	URL string `json:"url"`
 	// Protocol captures the protocol type: http, http2 or tcp. Note that the CF `protocol` field is only available
 	// for CF deployments that use HTTP/2 routing.


### PR DESCRIPTION
@gciavarrini PTAL. I had to make changes after reviewing the enhancement and realized that some of the fields I could not find the source information in the CF pages. It might as well be that I either found them in CF V2 or that they are not properly documented. At this point I'd rather stick to the CF documentation defined here:
https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html
and make changes as we go on.

Mostly, I moved things around a bit and the biggest change is that `Routes` is now at the `Application` level, since I could not find any reference to back my understanding that processes can define their own routes.

Update:
* Changed `Route` to contain a `url` field that maps to a `URL` structure in go, since the CF route field can be represented as a URL as well.
* Added `space` to the metadata in case we capture the value at runtime.